### PR TITLE
fix top-level resource optional id & add test cases for type/id requirements

### DIFF
--- a/lib/jsonapi/parser/document.rb
+++ b/lib/jsonapi/parser/document.rb
@@ -36,7 +36,7 @@ module JSONAPI
       # @api private
       def self.parse_data!(data)
         if data.is_a?(Hash)
-          parse_resource!(data)
+          parse_primary_resource!(data)
         elsif data.is_a?(Array)
           data.each { |res| parse_resource!(res) }
         elsif data.nil?

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -72,7 +72,23 @@ describe JSONAPI::Parser, '.parse_response!' do
     expect { JSONAPI.parse_response!(payload) }.to_not raise_error
   end
 
-  it 'fails when an element is missing type or id' do
+  it 'fails when a top-level data array resource object is missing id' do
+    payload = {
+      'data' => [
+        {
+          'type' => 'articles',
+          'attributes' => {'title' => 'JSON API paints my bikeshed!'}
+        }
+      ]
+    }
+
+    expect { JSONAPI.parse_response!(payload) }.to raise_error(
+      JSONAPI::Parser::InvalidDocument,
+      'A resource object must have an id.'
+    )
+  end
+
+  it 'fails when a relationship object is missing id' do
     payload = {
       'data' => [
         {
@@ -91,5 +107,29 @@ describe JSONAPI::Parser, '.parse_response!' do
       JSONAPI::Parser::InvalidDocument,
       'A resource identifier object MUST contain ["id", "type"] members.'
     )
+  end
+
+  it 'fails when the top-level resource object has no type' do
+    payload = {
+      'data' => {
+        'id' => '1'
+      }
+    }
+
+    expect { JSONAPI.parse_response!(payload) }.to raise_error(
+      JSONAPI::Parser::InvalidDocument,
+      'A resource object must have a type.'
+    )
+  end
+
+  it 'passes when the top-level resource object has no id' do
+    payload = {
+      'data' => {
+        'type' => 'articles',
+        'attributes' => {'title' => 'JSON API paints my bikeshed!'}
+      }
+    }
+
+    expect { JSONAPI.parse_response!(payload) }.to_not raise_error
   end
 end


### PR DESCRIPTION
on client requesting to create a resource on the server

This happened after seeing https://github.com/jsonapi-rb/jsonapi-deserializable/issues/21 and trying to figure out whether I can use that or not (after having false starts with a lot of ruby json-api libraries).

The code was already structured to handle the optional top-level id, it just seems be wired up wrong and was missing a test case. This will need a review as I'm not 100% sure of what the spec says, especially about the case where the top-level is an array of resource objects rather than a single one. I think this makes sense, but it might be wrong.